### PR TITLE
[Fix] fixed embedding construction bug when setting emb_strategy to 'w2v'

### DIFF
--- a/graph4nlp/pytorch/modules/graph_construction/embedding_construction.py
+++ b/graph4nlp/pytorch/modules/graph_construction/embedding_construction.py
@@ -282,6 +282,9 @@ class EmbeddingConstruction(EmbeddingConstructionBase):
                 feat = batch_gd.split_features(feat)
 
         if self.seq_info_encode_layer is None and "seq_bert" not in self.word_emb_layers:
+            if isinstance(feat, list):
+                feat = torch.cat(feat, -1)
+
             batch_gd.batch_node_features["node_feat"] = feat
 
             return batch_gd


### PR DESCRIPTION
## Description
Fixed embedding construction bug when setting `emb_strategy` variable to 'w2v', as reported in #400. The fix was to add check condition to handle the reported special case which resulted in `feat` variable being a list.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../README.md).